### PR TITLE
fix: add back utc offset to timestamp from API

### DIFF
--- a/src/components/Co2Graph.vue
+++ b/src/components/Co2Graph.vue
@@ -78,7 +78,10 @@ const displayUnit = computed(() => {
 
 const timeseries = computed(() =>
   props.samplePool?.map((s) => {
-    return { x: s.timestamp_s * 1000, y: s.co2_ppm };
+    return {
+      x: dayjs.unix(s.timestamp_s).add(dayjs().utcOffset(), "m"),
+      y: s.co2_ppm,
+    };
   })
 );
 


### PR DESCRIPTION
this isn't entirely correct, since the utcOffset will be determined by the timezone of the user of the dashboard
what we actually need is the timezone of the sensor, but this seems like a practical workaround